### PR TITLE
Fix issue empties

### DIFF
--- a/FloFlyout.lua
+++ b/FloFlyout.lua
@@ -70,6 +70,10 @@ local L = FLOFLYOUT_L10N_STRINGS
 -- Functions
 -------------------------------------------------------------------------------
 
+function isEmpty(s)
+	return s == nil or s == ''
+end
+
 function FloFlyout.ReadCmd(line)
 	local cmd, arg1, arg2 = strsplit(' ', line or "", 3);
 
@@ -228,7 +232,7 @@ function FloFlyoutFrame_OnEvent(self, event, ...)
 	if event == "SPELL_UPDATE_COOLDOWN" then
 		local i = 1
 		local button = _G[self:GetName().."Button"..i]
-		while (button and button:IsShown() and button.spellID) do
+		while (button and button:IsShown() and not isEmpty(button.spellID)) do
 			SpellFlyoutButton_UpdateCooldown(button)
 			i = i+1
 			button = _G[self:GetName().."Button"..i]
@@ -437,11 +441,11 @@ local function Opener_PreClick(self, button, down)
 	local buttonList = { FloFlyoutFrame:GetChildren() }
 	table.remove(buttonList, 1)
 	for i, buttonRef in ipairs(buttonList) do
-		if spellList[i] then
-			buttonRef.spellID = spellList[i]
-			buttonRef.actionType = typeList[i]
-			local icon = FloFlyout:GetTexture(typeList[i], spellList[i])
-			_G[buttonRef:GetName().."Icon"]:SetTexture(icon)
+		buttonRef.spellID = spellList[i]
+		buttonRef.actionType = typeList[i]
+		local icon = FloFlyout:GetTexture(typeList[i], spellList[i])
+		_G[buttonRef:GetName().."Icon"]:SetTexture(icon)
+		if true or not isEmpty(spellList[i]) then
 			SpellFlyoutButton_UpdateCooldown(buttonRef)
 			SpellFlyoutButton_UpdateState(buttonRef)
 			SpellFlyoutButton_UpdateUsable(buttonRef)
@@ -588,15 +592,17 @@ function FloFlyout:CreateOpener(name, idFlyout, actionId, direction, actionButto
 		_classicUI.LayoutActionButton(opener, typeActionButton)
 		opener:SetScale(actionButton:GetScale())
 	end
-	if actionButton:GetSize() and actionButton:IsRectValid() then
-		opener:SetAllPoints(actionButton)
-	else
-		local spacerName = "ActionBarButtonSpacer"..tostring(actionButton.index)
-		local children = {actionButton:GetParent():GetChildren()}
-		for _, child in ipairs(children) do
-			if child:GetName() == spacerName then
-				opener:SetAllPoints(child)
-				break;
+	if actionButton then
+		if actionButton:GetSize() and actionButton:IsRectValid() then
+			opener:SetAllPoints(actionButton)
+		else
+			local spacerName = "ActionBarButtonSpacer"..tostring(actionButton.index)
+			local children = {actionButton:GetParent():GetChildren()}
+			for _, child in ipairs(children) do
+				if child:GetName() == spacerName then
+					opener:SetAllPoints(child)
+					break;
+				end
 			end
 		end
 	end

--- a/FloFlyout.lua
+++ b/FloFlyout.lua
@@ -445,7 +445,7 @@ local function Opener_PreClick(self, button, down)
 		buttonRef.actionType = typeList[i]
 		local icon = FloFlyout:GetTexture(typeList[i], spellList[i])
 		_G[buttonRef:GetName().."Icon"]:SetTexture(icon)
-		if true or not isEmpty(spellList[i]) then
+		if not isEmpty(spellList[i]) then
 			SpellFlyoutButton_UpdateCooldown(buttonRef)
 			SpellFlyoutButton_UpdateState(buttonRef)
 			SpellFlyoutButton_UpdateUsable(buttonRef)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# FloFlyout
+wow addon to provide custom flyout menus - created by Boboseb


### PR DESCRIPTION
[https://github.com/ScottIngram/FloFlyout/issues/1](https://github.com/ScottIngram/FloFlyout/issues/1)

if you drag an empty flyout (has no spells etc, but has only the single empty placeholder) to your action bar and click it (or log in and trigger an ENTER_WORLD event), then lua errors happen inside the WoW API code.

ERROR MSG:

Message: bad argument https://github.com/ScottIngram/FloFlyout/issues/1 to '?' (outside of expected range -2147483648 to 2147483647 - Usage: local cooldownSpellID = C_UnitAuras.GetCooldownAuraBySpellID(spellID))
Time: Sat Mar 18 21:27:42 2023
Count: 1
Stack: bad argument https://github.com/ScottIngram/FloFlyout/issues/1 to '?' (outside of expected range -2147483648 to 2147483647 - Usage: local cooldownSpellID = C_UnitAuras.GetCooldownAuraBySpellID(spellID))
[string "=[C]"]: in function GetCooldownAuraBySpellID' [string "@Interface/FrameXML/ActionButton.lua"]:569: in function ActionButton_UpdateCooldown'
[string "@Interface/FrameXML/SpellFlyout.lua"]:84: in function `SpellFlyoutButton_UpdateCooldown'
[string "@Interface/AddOns/FloFlyout/FloFlyout.lua"]:451: in function <Interface/AddOns/FloFlyout/FloFlyout.lua:430>